### PR TITLE
Check desc

### DIFF
--- a/gtk.css
+++ b/gtk.css
@@ -5,7 +5,6 @@
 4	    transition: 0.2s;
 5	    border-radius: 3;
 6	    margin: 5;
-7	    box-shadow: none;
 8	    background-color: rgba(255,255,255,0.04);
 9	}
 10	


### PR DESCRIPTION
Removed the line which removes box shadows from `.xfce4-panel button` and `.genmon_plugin` , so that the user's theme can draw underline or other decorations using box-shadow on the hovered/active button on the panel.
Before:
![image](https://user-images.githubusercontent.com/86041547/177001695-5204ae0b-c3c6-429c-8592-6f534ecec707.png)
After:
![image](https://user-images.githubusercontent.com/86041547/177001712-655c5276-3dd6-43a6-990f-ea38ca8e9940.png)
Please note that the decoration may and will vary from theme to theme, or, in fact, you may have still have no decoration at all, depending on which theme you use.